### PR TITLE
Add dev env container and instructions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+ARG DOCKER_TAG=latest
+FROM espressif/idf:${DOCKER_TAG}
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+RUN apt-get update -y && apt-get -y install udev usbutils
+
+RUN echo "source /opt/esp/idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
+
+ENTRYPOINT [ "/opt/esp/entrypoint.sh" ]
+
+CMD ["/bin/bash", "-c"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "ESP-IDF QEMU",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "idf.espIdfPath": "/opt/esp/idf",
+        "idf.toolsPath": "/opt/esp",
+        "idf.gitPath": "/usr/bin/git"
+      },
+      "extensions": [
+        "espressif.esp-idf-extension",
+        "espressif.esp-idf-web"
+      ]
+    }
+  },
+  "runArgs": [
+    "--privileged"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "ms-vscode-remote.remote-containers",
+        "ms-vscode-remote.vscode-remote-extensionpack",
+        "espressif.esp-idf-extension"
+    ]
+}

--- a/ConcatNFCRegProxy/esp32/.gitignore
+++ b/ConcatNFCRegProxy/esp32/.gitignore
@@ -1,2 +1,1 @@
-build/*
-.vscode/*
+build/

--- a/ConcatNFCRegProxy/esp32/.vscode/settings.json
+++ b/ConcatNFCRegProxy/esp32/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "idf.pythonInstallPath": "/opt/esp/python_env/idf6.0_py3.12_env/bin/python",
+  "idf.port": "/dev/ttyACM0",
+  "idf.openOcdConfigs": [
+    "board/esp32s3-builtin.cfg"
+  ],
+  "idf.customExtraVars": {
+    "IDF_TARGET": "esp32s3"
+  },
+  "idf.flashType": "UART"
+}

--- a/ConcatNFCRegProxy/esp32/README.md
+++ b/ConcatNFCRegProxy/esp32/README.md
@@ -1,0 +1,55 @@
+# ESP32 NFC Reader Application
+
+This code runs the NFC reader component on an ESP32 device connected to a PN532 chip. The library is written for a high-speed UART (HSU) connection, check your datasheet and adjust the pins in main.cpp if your board layout differs.
+
+## Developing
+
+### Windows
+
+This is an abbreviated version of the [ESP-IDF setup guide](https://docs.espressif.com/projects/vscode-esp-idf-extension/en/latest/additionalfeatures/docker-container.html) for Docker Container development in VSCode.
+
+#### Prerequisites
+
+* Install WSL2, preferably Ubuntu (the default).
+  * `wsl --install`
+* Install usbipd, a tool to make USB devices available inside Linux containers from a Windows host.
+  * `winget install usbipd`
+* Ensure WSL Ubuntu integration is enabled in Docker for Windows.
+  * Settings -> Resources -> WSL Integration -> Enable Ubuntu -> Apply & Restart
+* Install workspace recommended extensions. VSCode should prompt you when you open the repo, make sure they're installed.
+
+#### First-time setup
+
+The following steps should be performed in order.
+
+1. Open a terminal in your WSL distro, such as Ubuntu, to make sure it's alive.
+2. Attach the USB cable from your computer to the COM usb port of the device.
+    * The USB port on the ESP32S3 is not used for programming.
+3. In an Windows PowerShell Administrator terminal run the usbipd command to list available USB devices.
+    * `usbipd list`
+4. Search the list for something like `USB-Enhanced-SERIAL CH343 (COM8)` and take note of the BUSID value.
+    * If in doubt you can run `usbipd list` before and after connecting the device to see how the list changes.
+    * The BUSID will be something like `2-8`, take note of the number.
+5. Capture the USB device for redirection with the `attach` command in the pwsh terminal.
+    * `usbipd attach --wsl --busid <THE_BUS_ID_FROM_STEP_3> --auto-attach`
+    * This will make the device available in WSL.
+6. In the bash terminal run the command `dmesg` and confirm the last few messages indicate a newly attached device.
+7. In Visual Studio Code run `File -> Open Workspace From File` and select the `esp32.code-workspace` file in the root of the repo.
+8. The VSCode window will restart, opening the esp32 project workspace. You will be prompted to re-open the workspace _in a dev container_, click yes.
+    * If you aren't prompted or miss the prompt you can click the `><` icon in the bottom left of VSCode to open the Remote Connection menu, then select `Reopen in container`.
+9. Once everything is warmed up you'll be greeted with the ESP-IDF splash screen. Along the bottom menu bar you should be able to switch `/dev/tty` to `/dev/ttyACM0` from the menu.
+    * If `/dev/ttyACM0` isn't available the container didn't notice the device on startup.
+    * Try clicking the `><` connection icon and re-building the container.
+10. Confirm the device can connect by opening the Serial Monitor by clicking the little screen 🖥️ icon.
+
+You can build and flash as normal.
+
+Once you've done the above setup once you can abbreviate the steps:
+
+1. Plug in the USB device BEFORE launching the dev container.
+2. Open the workspace, then launch the dev container.
+
+#### Reasons for this setup
+
+* Container removes local system dependencies for development.
+* The ESP-IDF seems to require the project files to be at the root of the active VSCode workspace to function correctly.

--- a/esp32.code-workspace
+++ b/esp32.code-workspace
@@ -1,0 +1,18 @@
+{
+  "folders": [
+    {
+      "path": "./ConcatNFCRegProxy/esp32"
+    }
+  ],
+  "settings": {
+    "idf.pythonInstallPath": "/opt/esp/python_env/idf6.0_py3.12_env/bin/python",
+    "idf.port": "/dev/ttyACM0",
+    "idf.openOcdConfigs": [
+      "board/esp32s3-builtin.cfg"
+    ],
+    "idf.customExtraVars": {
+      "IDF_TARGET": "esp32s3"
+    },
+    "idf.flashType": "UART"
+  }
+}


### PR DESCRIPTION
I had a lot of trouble piecing together the slightly conflicting ESP-IDF instructions on setting up a dev env on Windows. After some trial and error I was able to get a stable workflow configured using these instructions and config files. Some of the configs are specific to my ESP32S3 based on their contents, not sure if it'd be disruptive to keep them, let me know.