### PR TITLE
Minor tweaks for ESP32S3 module

### DIFF
--- a/ConcatNFCRegProxy/esp32/dependencies.lock
+++ b/ConcatNFCRegProxy/esp32/dependencies.lock
@@ -6,5 +6,5 @@ dependencies:
 direct_dependencies:
 - idf
 manifest_hash: e44bf68eca6b7b264ddae08cd014cd3294c0473230381b6d6f88ed18ec879038
-target: esp32
+target: esp32s3
 version: 2.0.0

--- a/ConcatNFCRegProxy/esp32/main/main.cpp
+++ b/ConcatNFCRegProxy/esp32/main/main.cpp
@@ -19,6 +19,12 @@
 #include <cJSON.h>
 #define TAG "main"
 
+// ESP32S3 standard dev board layout
+#define HSU_HOST_RX GPIO_NUM_18
+#define HSU_HOST_TX GPIO_NUM_17
+#define HSU_UART_PORT UART_NUM_1
+#define HSU_BAUD_RATE 115200
+
 static PN532 *nfc;
 static ConCatTag *Tags;
 esp_err_t err;
@@ -28,7 +34,13 @@ bool debug_enabled = false;
 bool setup(void) {
     ESP_LOGI(TAG, "init PN532 in HSU mode");
 
-    PN532Interface *interface = new PN532InterfaceHSU(GPIO_NUM_19, GPIO_NUM_18, GPIO_NUM_NC, GPIO_NUM_NC, UART_NUM_1, 115200);
+    PN532Interface *interface = new PN532InterfaceHSU(
+        HSU_HOST_RX,
+        HSU_HOST_TX,
+        GPIO_NUM_NC,
+        GPIO_NUM_NC,
+        HSU_UART_PORT,
+        HSU_BAUD_RATE);
     nfc = new PN532(interface);
 
     gpio_reset_pin(GPIO_NUM_5);


### PR DESCRIPTION
This updates the pins for my [ESP32-S3-DevKitC](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-devkitc-1/user_guide_v1.1.html#hardware-reference) board, which puts the UART1 on GPIO 17 and 18 by default.