### PR TITLE
Changed the way we detect NTAG version.

### DIFF
--- a/ConcatNFCRegProxy/esp32/components/pn532/include/PN532.h
+++ b/ConcatNFCRegProxy/esp32/components/pn532/include/PN532.h
@@ -95,6 +95,7 @@
 
 // NTAG Commands
 #define NTAG_CMD_PWD_AUTH                   (0x1B)
+#define NTAG_CMD_GET_VERSION                (0x60)
 
 // Prefixes for NDEF Records (to identify record type)
 #define NDEF_URIPREFIX_NONE                 (0x00)

--- a/ConcatNFCRegProxy/esp32/main/ConCatTag.cpp
+++ b/ConcatNFCRegProxy/esp32/main/ConCatTag.cpp
@@ -292,6 +292,7 @@ ConCatTag::ConCatTag(PN532 *i_nfc) {
 
 bool ConCatTag::IsTagModelValid(){
     NTAG2XX_INFO ntag_model;
+
     esp_err_t err = nfc->ntag2xx_get_model(&ntag_model);
     if (err != ESP_OK)
         return false;


### PR DESCRIPTION
Found official NTAG216 with a different size memory in page 3. Used the same method we use in the golang version to determine card type (GET_VERSION)